### PR TITLE
AMI testing fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 requires = [
     'boto3==1.3.1',
     'botocore==1.4.13',
+    'click==6.2',
     'docutils==0.12',
     'funcsigs==1.0.2',
     'futures==3.0.5',

--- a/src/spacel/model/manifest.py
+++ b/src/spacel/model/manifest.py
@@ -36,9 +36,4 @@ class AgentManifest(object):
                     logger.warn('Invalid manifest: duplicate instance volume.')
                     return False
                 volume_ids.add(instance)
-
-        if not self.systemd:
-            logger.warn('Invalid manifest: no units provided.')
-            return False
-
         return True

--- a/src/test/cli/test_services.py
+++ b/src/test/cli/test_services.py
@@ -12,9 +12,7 @@ class TestServices(unittest.TestCase):
         self._meta.az = 'us-east-1a'
         self._meta.instance_id = 'i-123456'
         self._meta.orbit = 'test-orbit'
-        self._meta.user_data = {
-            'systemd': {'foo.service': ''}
-        }
+        self._meta.user_data = {}
 
         self._signaller = MagicMock(spec=CloudFormationSignaller)
 
@@ -24,7 +22,11 @@ class TestServices(unittest.TestCase):
     def test_start_services_invalid(self, _, cf_factory, aws_meta_factory):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
-        del self._meta.user_data['systemd']
+        # The same instance volume is assigned twice:
+        self._meta.user_data['volumes'] = {
+            'foo': {'instance': 0},
+            'bar': {'instance': 0}
+        }
 
         start_services()
 


### PR DESCRIPTION
- click needs to be added to setup.py (AMI build uses this instead of
  requirements.txt)
- Unit-less manifests are ok after all (bastion hosts don't have any
  services)