### PR TITLE
ElbHealthCheck.health dynamic

### DIFF
--- a/src/spacel/agent/healthcheck.py
+++ b/src/spacel/agent/healthcheck.py
@@ -1,0 +1,39 @@
+import time
+
+
+def get_int(params, key, default):
+    try:
+        return int(params.get(key))
+    except:
+        return default
+
+
+def get_float(params, key, default):
+    try:
+        return float(params.get(key))
+    except:
+        return default
+
+
+class BaseHealthCheck(object):
+    def __init__(self, back_off_scale):
+        self._back_off_scale = back_off_scale
+
+    def _check(self, health_check, predicate, *args):
+        timeout = get_float(health_check, 'timeout', 900)
+        max_interval = get_float(health_check, 'max_interval', 10)
+        max_retries = get_int(health_check, 'max_retries', -1)
+
+        retries = 0
+        start = time.time()
+        while retries < max_retries or max_retries < 0:
+            if predicate(*args):
+                return True
+
+            if (time.time() - start) > timeout:
+                return False
+            back_off = (2 ** retries) * self._back_off_scale
+            back_off = min(back_off, max_interval)
+            retries += 1
+            time.sleep(back_off)
+        return False

--- a/src/spacel/agent/instance.py
+++ b/src/spacel/agent/instance.py
@@ -2,40 +2,30 @@ import logging
 import time
 import urllib2
 import sys
+from spacel.agent.healthcheck import BaseHealthCheck
 
 logger = logging.getLogger('spacel')
 
 
-class InstanceManager(object):
+class InstanceManager(BaseHealthCheck):
     """
     Perform actions directly on this instance.
     """
 
     def __init__(self, back_off_scale=0.1):
-        self._back_off_scale = back_off_scale
+        super(InstanceManager, self).__init__(back_off_scale)
 
-    def health(self, manifest, timeout=900):
+    def health(self, manifest):
         """
         Healthcheck an endpoint from the manifest for timeout in s
         :param manifest:  Manifest.
-        :param timeout:  Timeout.
         :return: Health status (boolean)
         """
-        if not manifest.healthcheck.get('endpoint'):
+        healthcheck = manifest.healthcheck
+        if not healthcheck.get('endpoint'):
             return True
 
-        retries = 0
-        start = time.time()
-        while True:
-            if self._check_health(manifest.healthcheck):
-                return True
-
-            if (time.time() - start) > timeout:
-                return False
-            back_off = (2 ** retries) * self._back_off_scale
-            back_off = min(back_off, 10)
-            retries += 1
-            time.sleep(back_off)
+        return self._check(healthcheck, self._check_health, healthcheck)
 
     @staticmethod
     def _check_health(healthcheck):
@@ -49,7 +39,7 @@ class InstanceManager(object):
         endpoint = healthcheck.get('endpoint')
         # we need to ping the host container
         endpoint = (endpoint.replace('localhost', '172.17.0.1')
-                            .replace('127.0.0.1', '172.17.0.1'))
+                    .replace('127.0.0.1', '172.17.0.1'))
         virtual_host = healthcheck.get('virtual_host', 'localhost')
         protocol = healthcheck.get('protocol', 'http')
         forwarded_protocol = healthcheck.get('forwarded_protocol', 'https')

--- a/src/spacel/aws/elb.py
+++ b/src/spacel/aws/elb.py
@@ -6,30 +6,35 @@ logger = logging.getLogger('spacel')
 
 
 class ElbHealthCheck(object):
-    def __init__(self, clients, meta):
+    def __init__(self, clients, meta, sleep_time=5):
         self._elb = clients.elb()
         self._instance_id = meta.instance_id
+        self._sleep_time = sleep_time
 
     def health(self, manifest):
         if not manifest.elb:
             logger.debug('ELB not configured.')
             return True
 
-        for attempt in range(30):
+        start_time = time.time()
+        attempt = 1
+        while (time.time() - start_time) < manifest.elb_time:
             logger.debug('Querying ELB, attempt #%d.', attempt)
             state = self._instance_states(manifest)
             if state == 'inservice':
                 logger.debug('Instance %s is healthy in %s.', self._instance_id,
                              manifest.elb)
                 return True
-            time.sleep(5)
+
+            time.sleep(self._sleep_time)
+            attempt += 1
         return False
 
     def _instance_states(self, manifest):
         try:
             instance_health = self._elb.describe_instance_health(
-                    LoadBalancerName=manifest.elb,
-                    Instances=[{'InstanceId': self._instance_id}])
+                LoadBalancerName=manifest.elb,
+                Instances=[{'InstanceId': self._instance_id}])
             for state in instance_health.get('InstanceStates', ()):
                 return state['State'].lower()
         except ClientError:

--- a/src/spacel/model/manifest.py
+++ b/src/spacel/model/manifest.py
@@ -14,7 +14,8 @@ class AgentManifest(object):
                         for label, vol_params in
                         params.get('volumes', {}).items()}
         self.elb = params.get('elb')
-        self.elb_time = params.get('elb_time', 30)
+        if isinstance(self.elb, str):
+            self.elb = {'name': self.elb}
         self.healthcheck = params.get('healthcheck', {})
 
     @property

--- a/src/spacel/model/manifest.py
+++ b/src/spacel/model/manifest.py
@@ -14,6 +14,7 @@ class AgentManifest(object):
                         for label, vol_params in
                         params.get('volumes', {}).items()}
         self.elb = params.get('elb')
+        self.elb_time = params.get('elb_time', 30)
         self.healthcheck = params.get('healthcheck', {})
 
     @property

--- a/src/test/agent/test_healthcheck.py
+++ b/src/test/agent/test_healthcheck.py
@@ -1,0 +1,25 @@
+import unittest
+from mock import MagicMock
+from spacel.agent.healthcheck import BaseHealthCheck
+
+
+class TestBaseHealthCheck(unittest.TestCase):
+    def setUp(self):
+        self.check_params = {}
+        self.health_check = BaseHealthCheck(0.00001)
+
+    def test_check_healthy(self):
+        health = self.health_check._check(self.check_params, lambda: True)
+        self.assertTrue(health)
+
+    def test_check_time_out(self):
+        self.check_params['timeout'] = 0.001
+        health = self.health_check._check(self.check_params, lambda: False)
+        self.assertFalse(health)
+
+    def test_check_exceed_max_retries(self):
+        self.check_params['max_retries'] = 2
+        predicate = MagicMock(return_value=False)
+        health = self.health_check._check(self.check_params, predicate)
+        self.assertFalse(health)
+        self.assertEquals(2, predicate.call_count)

--- a/src/test/agent/test_instance.py
+++ b/src/test/agent/test_instance.py
@@ -12,19 +12,20 @@ class TestInstanceManager(unittest.TestCase):
                 'endpoint': 'localhost/',
                 'virtual_host': 'spacel-agent.com',
                 'protocol': 'http',
-                'forwarded_protocol': 'https'
+                'forwarded_protocol': 'https',
+                'timeout': 0.01
             }
         })
 
     def test_health(self):
         self.instance._check_health = MagicMock(return_value=True)
-        result = self.instance.health(self.manifest, timeout=0.01)
+        result = self.instance.health(self.manifest)
         self.assertEqual(result, True)
         self.assertEqual(self.instance._check_health.call_count, 1)
 
     def test_health_fail(self):
         self.instance._check_health = MagicMock(return_value=False)
-        result = self.instance.health(self.manifest, timeout=0.01)
+        result = self.instance.health(self.manifest)
         self.assertEqual(result, False)
         self.assertEqual(self.instance._check_health.call_count, 8)
 

--- a/src/test/aws/__init__.py
+++ b/src/test/aws/__init__.py
@@ -14,11 +14,13 @@ class MockedClientTest(unittest.TestCase):
         self.cloudformation = MagicMock()
         self.dynamodb = MagicMock()
         self.ec2 = MagicMock()
+        self.elb = MagicMock()
         self.clients = MagicMock(spec=ClientCache)
         self.clients.autoscaling.return_value = self.autoscaling
         self.clients.cloudformation.return_value = self.cloudformation
         self.clients.dynamodb.return_value = self.dynamodb
         self.clients.ec2.return_value = self.ec2
+        self.clients.elb.return_value = self.elb
         self.meta = MagicMock(spec=AwsMeta)
         self.meta.instance_id = INSTANCE_ID
         self.meta.az = AVAILABILITY_ZONE

--- a/src/test/aws/test_elb.py
+++ b/src/test/aws/test_elb.py
@@ -1,0 +1,52 @@
+from botocore.exceptions import ClientError
+from spacel.aws.elb import ElbHealthCheck
+from test.aws import MockedClientTest, INSTANCE_ID
+
+ELB_NAME = 'elb-123456'
+INSTANCE_IN_SERVICE = {'InstanceStates': [{'State': 'InService'}]}
+
+
+class TestElbHealthCheck(MockedClientTest):
+    def setUp(self):
+        super(TestElbHealthCheck, self).setUp()
+        self.elb_health = ElbHealthCheck(self.clients, self.meta, 0.000001)
+
+        self.manifest.elb = ELB_NAME
+
+    def test_health_no_elb(self):
+        self.manifest.elb = None
+
+        health = self.elb_health.health(self.manifest)
+
+        self.assertTrue(health)
+        self.elb.describe_instance_health.assert_not_called()
+
+    def test_health_timeout(self):
+        self.manifest.elb_time = 0.01
+
+        health = self.elb_health.health(self.manifest)
+
+        self.assertFalse(health)
+        self.assertTrue(self.elb.describe_instance_health.call_count > 1)
+
+    def test_health_healthy(self):
+        self.elb.describe_instance_health.return_value = INSTANCE_IN_SERVICE
+
+        health = self.elb_health.health(self.manifest)
+
+        self.assertTrue(health)
+        self.elb.describe_instance_health.assert_called_once_with(
+            LoadBalancerName=ELB_NAME,
+            Instances=[{'InstanceId': INSTANCE_ID}]
+        )
+
+    def test_health_retry(self):
+        describe_exception = ClientError({'Error': {'Message': 'Kaboom'}},
+                                         'DescribeInstanceHealth')
+        self.elb.describe_instance_health.side_effect = [
+            describe_exception,
+            INSTANCE_IN_SERVICE
+        ]
+
+        health = self.elb_health.health(self.manifest)
+        self.assertTrue(health)

--- a/src/test/aws/test_elb.py
+++ b/src/test/aws/test_elb.py
@@ -11,7 +11,7 @@ class TestElbHealthCheck(MockedClientTest):
         super(TestElbHealthCheck, self).setUp()
         self.elb_health = ElbHealthCheck(self.clients, self.meta, 0.000001)
 
-        self.manifest.elb = ELB_NAME
+        self.manifest.elb = {'name': ELB_NAME}
 
     def test_health_no_elb(self):
         self.manifest.elb = None
@@ -22,7 +22,7 @@ class TestElbHealthCheck(MockedClientTest):
         self.elb.describe_instance_health.assert_not_called()
 
     def test_health_timeout(self):
-        self.manifest.elb_time = 0.01
+        self.manifest.elb['timeout'] = 0.01
 
         health = self.elb_health.health(self.manifest)
 

--- a/src/test/model/test_manifest.py
+++ b/src/test/model/test_manifest.py
@@ -4,6 +4,7 @@ from spacel.model.manifest import AgentManifest
 
 INSTANCE_ID = 'i-123456'
 EIP_ALLOCATION = 'eip-123456'
+ELB_ID = 'elb-123456'
 
 
 class TestAgentManifest(unittest.TestCase):
@@ -58,3 +59,17 @@ class TestAgentManifest(unittest.TestCase):
         }})
 
         self.assertFalse(manifest.valid)
+
+    def test_elb_string(self):
+        manifest = AgentManifest({'elb': ELB_ID})
+
+        self.assertEquals(ELB_ID, manifest.elb.get('name'))
+
+    def test_elb_object(self):
+        manifest = AgentManifest({'elb': {'name': ELB_ID}})
+
+        self.assertEquals(ELB_ID, manifest.elb.get('name'))
+
+    def test_elb_empty(self):
+        manifest = AgentManifest({})
+        self.assertIsNone(manifest.elb)


### PR DESCRIPTION
Instead of a fixed 30 checks every 5 seconds, allow the manifest to
specify how long it should take before giving up on ELB health.

Discovered with elasticsearch on a t2.nano
(http://i.giphy.com/jwNInih10Qb9C.gif)