### PR TITLE
WEBOPS-1052: Remove Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,0 @@
-dockerBuild {
-    name = 'pwagner/spacel-agent'
-    testCommand = 'make composetest'
-    reports = [
-        tests: '**/build/nosetests.xml',
-        tasks: '**/*.py'
-    ]
-}
-

--- a/jenkins.json
+++ b/jenkins.json
@@ -1,0 +1,6 @@
+{
+	"dockerImage": "pebbletech/spacel-agent",
+	"dockerRegistry": "hub.docker.com",
+	"junitReport": "**/build/nosetests.xml",
+	"coberturaReport": "**/build/coverage.xml"
+}


### PR DESCRIPTION
Jenkinsfile is slow, and github-branch-source can't be triggered by
tags.
Keeping build metadata in the project is a good idea though...