### PR TITLE
WEBOPS-1065: dump `systemctl status` on failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM alpine:3.4
+FROM debian:jessie
 
 COPY requirements.txt /app/requirements.txt
 
-RUN apk add --update \
+RUN apt-get update && apt-get -y --no-install-recommends install \
     git \
     g++ \
     python \
     python-dev \
-    py-pip \
-    py-dbus \
+    python-pip \
+    python-dbus \
   && pip install -r /app/requirements.txt \
-  && apk del \
+  && apt-get remove --purge --auto-remove -y \
+     gcc \
      git \
      g++ \
+     perl-modules \
      python-dev \
-  && rm -rf /var/cache/apk/*
+  && rm -rf /tmp/* /var/tmp/
 
 COPY src/ /app
 WORKDIR /app

--- a/src/spacel/agent/instance.py
+++ b/src/spacel/agent/instance.py
@@ -1,5 +1,4 @@
 import logging
-import time
 import urllib2
 import sys
 from spacel.agent.healthcheck import BaseHealthCheck
@@ -51,8 +50,10 @@ class InstanceManager(BaseHealthCheck):
             req.add_header('X-Forwarded-Proto', str(forwarded_protocol))
             resp = urllib2.urlopen(req)
             return resp.getcode() == 200
-        except:
-            e = sys.exc_info()[0]
+
+        except urllib2.URLError as e:
+            logger.error(e.reason)
+        except Exception as e:
             logger.info('Failed to execute healthcheck on "%s"', url)
-            logger.exception(e)
+            logger.error(e.message)
             return False

--- a/src/spacel/agent/systemd.py
+++ b/src/spacel/agent/systemd.py
@@ -1,7 +1,8 @@
 import logging
+import subprocess
 import os
 
-logger = logging.getLogger('spacel')
+logger = logging.getLogger('spacel.agent.systemd')
 
 
 class SystemdUnits(object):
@@ -55,6 +56,18 @@ class SystemdUnits(object):
                 unit.stop('replace')
             except:
                 logger.warn('Error stopping "%s".', unit_id, exc_info=True)
+
+    @staticmethod
+    def log_units(manifest):
+        """
+        Log `systemctl status` for each service/timer in a manifest.
+        :param manifest: Manifest.
+        :return: None
+        """
+        for unit in manifest.systemd.keys():
+            status_cmd = 'systemctl status -l --no-pager %s || exit 0' % unit
+            status = subprocess.check_output(status_cmd, shell=True)
+            logger.info('Systemd status:\n%s', status)
 
     def _get_units(self, manifest):
         manifest_units = set(manifest.systemd.keys())

--- a/src/spacel/cli/services.py
+++ b/src/spacel/cli/services.py
@@ -1,5 +1,6 @@
 import click
 import os
+import sys
 
 from spacel.agent import (ApplicationEnvironment, FileWriter, SystemdUnits,
                           InstanceManager)
@@ -75,3 +76,7 @@ def start_services():
         status = 'FAILURE'
 
     cf.notify(manifest, status=status)
+
+    if status != 'SUCCESS':
+        systemd.log_units(manifest)
+        sys.exit(1)

--- a/src/test/agent/test_systemd.py
+++ b/src/test/agent/test_systemd.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import MagicMock, call
+from mock import MagicMock, call, patch
 from spacel.model import AgentManifest
 from spacel.agent.systemd import SystemdUnits
 
@@ -100,3 +100,9 @@ class TestSystemdUnits(unittest.TestCase):
     def test_get_timers(self):
         timers = self.systemd._get_timers(self.manifest)
         self.assertEqual(set(['bar']), timers)
+
+    @patch('spacel.agent.systemd.subprocess')
+    def test_log_units(self, mock_subprocess):
+        self.systemd.log_units(self.manifest)
+
+        self.assertEquals(3, mock_subprocess.check_output.call_count)

--- a/src/test/cli/test_services.py
+++ b/src/test/cli/test_services.py
@@ -16,10 +16,11 @@ class TestServices(unittest.TestCase):
 
         self._signaller = MagicMock(spec=CloudFormationSignaller)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.Manager')
-    def test_start_services_invalid(self, _, cf_factory, aws_meta_factory):
+    def test_start_services_invalid(self, _, cf_factory, aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         # The same instance volume is assigned twice:
@@ -31,13 +32,15 @@ class TestServices(unittest.TestCase):
         start_services()
 
         self._signaller.notify.assert_called_with(ANY, status='FAILURE')
+        sys.exit.assert_called_with(1)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.FileWriter')
     @patch('spacel.cli.services.Manager')
     def test_start_services_valid(self, _, writer_factory, cf_factory,
-                                  aws_meta_factory):
+                                  aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         writer_factory.return_value = MagicMock()
@@ -45,6 +48,7 @@ class TestServices(unittest.TestCase):
         start_services()
 
         self._signaller.notify.assert_called_with(ANY, status='SUCCESS')
+        sys.exit.assert_not_called()
 
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
@@ -70,13 +74,14 @@ class TestServices(unittest.TestCase):
 
         self.assertEquals(volume_binder.attach.call_count, 1)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.ElasticIpBinder')
     @patch('spacel.cli.services.FileWriter')
     @patch('spacel.cli.services.Manager')
     def test_start_services_valid_eip_fail(self, _, writer_factory, eip_factory,
-                                           cf_factory, aws_meta_factory):
+                                           cf_factory, aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         writer_factory.return_value = MagicMock()
@@ -90,14 +95,16 @@ class TestServices(unittest.TestCase):
 
         self.assertEquals(eip_binder.assign_from.call_count, 1)
         self._signaller.notify.assert_called_with(ANY, status='FAILURE')
+        sys.exit.assert_called_with(1)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.ElbHealthCheck')
     @patch('spacel.cli.services.FileWriter')
     @patch('spacel.cli.services.Manager')
     def test_start_services_valid_elb_fail(self, _, writer_factory, elb_factory,
-                                           cf_factory, aws_meta_factory):
+                                           cf_factory, aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         writer_factory.return_value = MagicMock()
@@ -109,7 +116,9 @@ class TestServices(unittest.TestCase):
 
         self.assertEquals(elb_health_check.health.call_count, 1)
         self._signaller.notify.assert_called_with(ANY, status='FAILURE')
+        sys.exit.assert_called_with(1)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.SystemdUnits')
@@ -117,7 +126,7 @@ class TestServices(unittest.TestCase):
     @patch('spacel.cli.services.Manager')
     def test_start_services_valid_systemd_fail(self, _, writer_factory,
                                                systemd_factory, cf_factory,
-                                               aws_meta_factory):
+                                               aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         writer_factory.return_value = MagicMock()
@@ -129,7 +138,9 @@ class TestServices(unittest.TestCase):
 
         self.assertEquals(systemd_units.start_units.call_count, 1)
         self._signaller.notify.assert_called_with(ANY, status='FAILURE')
+        sys.exit.assert_called_with(1)
 
+    @patch('spacel.cli.services.sys')
     @patch('spacel.cli.services.AwsMeta')
     @patch('spacel.cli.services.CloudFormationSignaller')
     @patch('spacel.cli.services.FileWriter')
@@ -137,7 +148,7 @@ class TestServices(unittest.TestCase):
     @patch('spacel.cli.services.Manager')
     def test_start_services_valid_instance_fail(self, _, instance_factory,
                                                 writer_factory, cf_factory,
-                                                aws_meta_factory):
+                                                aws_meta_factory, sys):
         aws_meta_factory.return_value = self._meta
         cf_factory.return_value = self._signaller
         writer_factory.return_value = MagicMock()
@@ -149,3 +160,4 @@ class TestServices(unittest.TestCase):
 
         self.assertEquals(instance_health_check.health.call_count, 1)
         self._signaller.notify.assert_called_with(ANY, status='FAILURE')
+        sys.exit.assert_called_with(1)


### PR DESCRIPTION
This should be _just enough_ journald output to troubleshoot what went
wrong with your unit.

Modifying CLI to `exit 1` when sending a CF `FAILURE` signal; this is a
NOOP since `FAILURE` implies the instance won't live, but "feels right"
(TM).