### PR TITLE
WEBOPS-1065: CWL logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ boto3==1.3.1
 botocore==1.4.66
 click==6.2
 docutils==0.12
+eight==0.3.3
 funcsigs==1.0.2
+future==0.15.2
 futures==3.0.5
 jmespath==0.9.0
 mock==2.0.0
@@ -10,3 +12,4 @@ pbr==1.9.1
 pycrypto==2.6.1
 python-dateutil==2.5.3
 git+https://github.com/pebble/python-systemd.git
+watchtower==0.3.3

--- a/src/spacel/agent/instance.py
+++ b/src/spacel/agent/instance.py
@@ -53,6 +53,7 @@ class InstanceManager(BaseHealthCheck):
 
         except urllib2.URLError as e:
             logger.error(e.reason)
+            return False
         except Exception as e:
             logger.info('Failed to execute healthcheck on "%s"', url)
             logger.error(e.message)

--- a/src/spacel/aws/clients.py
+++ b/src/spacel/aws/clients.py
@@ -18,39 +18,42 @@ class ClientCache(object):
         Get AutoScaling client.
         :return: AutoScaling client.
         """
-        return self._client('autoscaling')
+        return self.client('autoscaling')
 
     def cloudformation(self):
         """
         Get CloudFormation client.
         :return: CloudFormation client.
         """
-        return self._client('cloudformation')
+        return self.client('cloudformation')
 
     def dynamodb(self):
         """
         Get DynamoDb client.
         :return: DynamoDb client.
         """
-        return self._client('dynamodb')
+        return self.client('dynamodb')
 
     def ec2(self):
         """
+        Get EC2 client.
         :return: EC2 client.
         """
-        return self._client('ec2')
+        return self.client('ec2')
 
     def elb(self):
         """
+        Get ELB client.
         :return: ELB client.
         """
-        return self._client('elb')
+        return self.client('elb')
 
     def elasticache(self):
         """
+        Get ElastiCache client.
         :return: ElastiCache client.
         """
-        return self._client('elasticache')
+        return self.client('elasticache')
 
     def kms(self, region):
         """
@@ -58,7 +61,7 @@ class ClientCache(object):
         :param region: Region.
         :return:  KMS Client.
         """
-        return self._client('kms', region)
+        return self.client('kms', region)
 
     def rds(self, region):
         """
@@ -66,14 +69,21 @@ class ClientCache(object):
         :param region:  Region.
         :return:  RDS client.
         """
-        return self._client('rds', region)
+        return self.client('rds', region)
 
-    def _client(self, client_type, region=None):
-        cached = self._clients.get(client_type)
+    def logs(self):
+        """
+        Get CloudWatchLogs client.
+        :return: CloudWatchLogs client.
+        """
+        return self.client('logs')
+
+    def client(self, service_name, region=None):
+        cached = self._clients.get(service_name)
         if cached:
             return cached
         region = region or self.region
-        logger.debug('Connecting to %s in %s.', client_type, region)
-        client = boto3.client(client_type, region)
-        self._clients[client_type] = client
+        logger.debug('Connecting to %s in %s.', service_name, region)
+        client = boto3.client(service_name, region)
+        self._clients[service_name] = client
         return client

--- a/src/spacel/cli/services.py
+++ b/src/spacel/cli/services.py
@@ -7,7 +7,7 @@ from spacel.agent import (ApplicationEnvironment, FileWriter, SystemdUnits,
                           InstanceManager)
 from spacel.aws import (AwsMeta, ClientCache, CloudFormationSignaller,
                         ElbHealthCheck, ElasticIpBinder, KmsCrypto, TagWriter)
-from spacel.log import setup_logging
+from spacel.log import setup_logging, setup_watchtower
 from spacel.model import AgentManifest
 from spacel.volumes import VolumeBinder
 
@@ -40,8 +40,10 @@ def start_services():
     # Get context:
     meta = AwsMeta()
     clients = ClientCache(meta.region)
-    cf = CloudFormationSignaller(clients, meta.instance_id)
     manifest = AgentManifest(meta.user_data)
+    setup_watchtower(clients, manifest)
+    cf = CloudFormationSignaller(clients, meta.instance_id)
+
 
     if manifest.valid:
         systemd = SystemdUnits(Manager())

--- a/src/spacel/log.py
+++ b/src/spacel/log.py
@@ -1,5 +1,11 @@
 import logging
 
+import watchtower
+
+logger = logging.getLogger('spacel')
+
+DEFAULT_CWL_LEVEL = logging.INFO
+
 
 def setup_logging(level=logging.DEBUG):  # pragma: no cover
     logging.basicConfig(level=logging.DEBUG,
@@ -7,6 +13,37 @@ def setup_logging(level=logging.DEBUG):  # pragma: no cover
     logging.getLogger('boto3').setLevel(logging.CRITICAL)
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
     logging.getLogger('dbus.proxies').setLevel(logging.CRITICAL)
-    spacel_logger = logging.getLogger('spacel')
-    spacel_logger.setLevel(level)
-    return spacel_logger
+    logger.setLevel(level)
+    return logger
+
+
+def parse_level(level_param, default_level):
+    if not level_param:
+        return default_level
+
+    parsed_level = logging.getLevelName(level_param)
+    if isinstance(parsed_level, int):
+        return parsed_level
+
+    logger.warn('Invalid log level: "%s"', level_param)
+    return default_level
+
+
+def setup_watchtower(clients, manifest):
+    deploy_logging = manifest.logging.get('deploy', {})
+    log_group = deploy_logging.get('group')
+    if not log_group:
+        logger.debug('Deployment logging not configured.')
+        return
+    level = parse_level(deploy_logging.get('level'), DEFAULT_CWL_LEVEL)
+
+    cwl = watchtower.CloudWatchLogHandler(
+        log_group=log_group,
+        boto3_session=clients,
+        use_queues=True,
+        send_interval=2,
+        create_log_group=False,
+        stream_name='spacel'
+    )
+    cwl.setLevel(level)
+    logging.getLogger('spacel').addHandler(cwl)

--- a/src/spacel/model/manifest.py
+++ b/src/spacel/model/manifest.py
@@ -19,6 +19,7 @@ class AgentManifest(object):
         self.healthcheck = params.get('healthcheck', {})
         self.tags = params.get('tags', ())
         self.caches = params.get('caches', {})
+        self.logging = params.get('logging', {})
 
     @property
     def all_files(self):

--- a/src/test/aws/test_clients.py
+++ b/src/test/aws/test_clients.py
@@ -55,3 +55,8 @@ class TestClientCache(unittest.TestCase):
     def test_rds(self, mock_boto3):
         self.clients.rds(REGION)
         mock_boto3.client.assert_called_once_with('rds', REGION)
+
+    @patch('spacel.aws.clients.boto3')
+    def test_logs(self, mock_boto3):
+        self.clients.logs()
+        mock_boto3.client.assert_called_once_with('logs', REGION)

--- a/src/test/test_log.py
+++ b/src/test/test_log.py
@@ -1,0 +1,51 @@
+import logging
+import unittest
+
+from mock import MagicMock, patch, ANY
+
+from spacel.aws import ClientCache
+from spacel.log import parse_level, setup_watchtower, DEFAULT_CWL_LEVEL
+from spacel.model import AgentManifest
+
+LOG_GROUP = 'test-log-group'
+
+
+class TestLogging(unittest.TestCase):
+    def setUp(self):
+        self.clients = MagicMock(spec=ClientCache)
+        self.manifest = AgentManifest({})
+
+    def test_parse_level_not_found(self):
+        level = parse_level(None, DEFAULT_CWL_LEVEL)
+        self.assertEquals(DEFAULT_CWL_LEVEL, level)
+
+    def test_parse_level_invalid(self):
+        level = parse_level('meow', DEFAULT_CWL_LEVEL)
+        self.assertEquals(DEFAULT_CWL_LEVEL, level)
+
+    def test_parse_level(self):
+        level = parse_level('INFO', DEFAULT_CWL_LEVEL)
+        self.assertEquals(logging.INFO, level)
+
+    @patch('spacel.log.watchtower')
+    def test_setup_watchtower_noop(self, watchtower):
+        setup_watchtower(self.clients, self.manifest)
+        watchtower.CloudWatchLogHandler.assert_not_called()
+
+    @patch('spacel.log.watchtower')
+    def test_setup_watchtower(self, watchtower):
+        self.manifest.logging = {
+            'deploy': {
+                'group': LOG_GROUP,
+                'level': 'DEBUG'
+            }
+        }
+        setup_watchtower(self.clients, self.manifest)
+        watchtower.CloudWatchLogHandler.assert_called_once_with(
+            log_group=LOG_GROUP,
+            boto3_session=self.clients,
+            use_queues=ANY,
+            send_interval=ANY,
+            create_log_group=False,
+            stream_name='spacel'
+        )


### PR DESCRIPTION
Toggled via manifest, you can customize the log group and log level.

An integrated handler is overkill for CoreOS (where the docker wrapper
forwards logs), but is needed for base Debian AMIs.