### PR TITLE
WEBOPS-1065: log level case insensitive

### DIFF
--- a/src/spacel/log.py
+++ b/src/spacel/log.py
@@ -21,7 +21,7 @@ def parse_level(level_param, default_level):
     if not level_param:
         return default_level
 
-    parsed_level = logging.getLevelName(level_param)
+    parsed_level = logging.getLevelName(level_param.upper())
     if isinstance(parsed_level, int):
         return parsed_level
 

--- a/src/test/test_log.py
+++ b/src/test/test_log.py
@@ -23,6 +23,10 @@ class TestLogging(unittest.TestCase):
         level = parse_level('meow', DEFAULT_CWL_LEVEL)
         self.assertEquals(DEFAULT_CWL_LEVEL, level)
 
+    def test_parse_level_case(self):
+        level = parse_level('warning', DEFAULT_CWL_LEVEL)
+        self.assertEquals(logging.WARNING, level)
+
     def test_parse_level(self):
         level = parse_level('INFO', DEFAULT_CWL_LEVEL)
         self.assertEquals(logging.INFO, level)


### PR DESCRIPTION
`debug` vs `DEBUG` shouldn't matter!