### PR TITLE
WEBOPS-945: decrypt individual keys

### DIFF
--- a/src/spacel/cli/services.py
+++ b/src/spacel/cli/services.py
@@ -63,7 +63,7 @@ def start_services():
 def process_manifest(clients, meta, systemd, manifest):
     # Dependency injection party!
     kms = KmsCrypto(clients)
-    app_env = ApplicationEnvironment(clients)
+    app_env = ApplicationEnvironment(clients, kms)
     file_writer = FileWriter(app_env, kms)
     instance = InstanceManager()
     eip = ElasticIpBinder(clients, meta)

--- a/src/spacel/security/payload.py
+++ b/src/spacel/security/payload.py
@@ -1,5 +1,5 @@
-from base64 import b64decode
 import json
+from base64 import b64decode, b64encode
 
 
 class EncryptedPayload(object):
@@ -10,9 +10,21 @@ class EncryptedPayload(object):
         self.key_region = key_region
         self.encoding = encoding
 
+    def json(self):
+        return json.dumps({
+            'iv': b64encode(self.iv),
+            'key': b64encode(self.key),
+            'key_region': self.key_region,
+            'ciphertext': b64encode(self.ciphertext),
+            'encoding': self.encoding,
+        }, sort_keys=True)
+
     @staticmethod
     def from_json(json_string):
-        json_obj = json.loads(json_string)
+        try:
+            json_obj = json.loads(json_string)
+        except ValueError:
+            return None
         return EncryptedPayload.from_obj(json_obj)
 
     @staticmethod

--- a/src/test/security/__init__.py
+++ b/src/test/security/__init__.py
@@ -1,0 +1,9 @@
+from spacel.security.payload import EncryptedPayload
+
+IV = b'0000000000000000'
+CIPHERTEXT = b'0000000000000000'
+KEY = b'0000000000000000'
+ENCODING = 'utf-8'
+REGION = 'us-east-1'
+
+PAYLOAD = EncryptedPayload(IV, CIPHERTEXT, KEY, REGION, ENCODING)

--- a/src/test/security/test_payload.py
+++ b/src/test/security/test_payload.py
@@ -1,11 +1,7 @@
 import unittest
-from spacel.security.payload import EncryptedPayload
 
-IV = b'0000000000000000'
-CIPHERTEXT = b'0000000000000000'
-KEY = b'0000000000000000'
-ENCODING = 'utf-8'
-REGION = 'us-east-1'
+from spacel.security.payload import EncryptedPayload
+from test.security import IV, CIPHERTEXT, KEY, ENCODING, REGION, PAYLOAD
 
 
 class TestEncryptedPayload(unittest.TestCase):
@@ -17,12 +13,25 @@ class TestEncryptedPayload(unittest.TestCase):
             "key": "MDAwMDAwMDAwMDAwMDAwMA==",
             "key_region": "us-east-1"
         }''')
+        self.assertTestPayload(payload)
+
+    def test_from_json_not_json(self):
+        payload = EncryptedPayload.from_json('meow')
+        self.assertIsNone(payload)
+
+    def test_from_json_invalid_json(self):
+        payload = EncryptedPayload.from_json('{}')
+        self.assertIsNone(payload)
+
+    def test_json_round_trip(self):
+        as_json = PAYLOAD.json()
+        self.assertIsInstance(as_json, str)
+        from_json = EncryptedPayload.from_json(as_json)
+        self.assertTestPayload(from_json)
+
+    def assertTestPayload(self, payload):
         self.assertEquals(IV, payload.iv)
         self.assertEquals(CIPHERTEXT, payload.ciphertext)
         self.assertEquals(KEY, payload.key)
         self.assertEquals(REGION, payload.key_region)
         self.assertEquals(ENCODING, payload.encoding)
-
-    def test_from_json_exception(self):
-        payload = EncryptedPayload.from_json('{}')
-        self.assertIsNone(payload)


### PR DESCRIPTION
This lets environment files be a mix of plaintext and encrypted entries,
which adds an additional layer of security when compared to encrypting
the _entire_ environment file (i.e. you can change 1 secret without
revealing _all_ secrets to update the whole file).

Encrypted entries must begin with their plaintext key, to prevent
attacks based on swapping encrypted values to weaker keys (i.e. those
available via API, logged at startup, etc).