### PR TITLE
Webops 972/cw stats

### DIFF
--- a/src/spacel/agent/mixin/__init__.py
+++ b/src/spacel/agent/mixin/__init__.py
@@ -1,0 +1,2 @@
+from .cloudwatch_logs import SetupCloudWatchLogs
+from .cloudwatch_stats import SetupCloudWatchStats

--- a/src/spacel/agent/mixin/base.py
+++ b/src/spacel/agent/mixin/base.py
@@ -1,0 +1,26 @@
+import os
+
+
+class BaseMixinWriter(object):
+    """
+    Shared functionality for writing Systemd mixins.
+    """
+
+    def __init__(self, systemd, systemd_path='/etc/systemd/system'):
+        self._systemd = systemd
+        self._systemd_path = systemd_path
+
+    def _write_mixin(self, service, label, environment=()):
+        mixin = '[Service]\n'
+
+        if environment:
+            for key, value in environment.items():
+                mixin += 'Environment="%s=%s"\n' % (key, value)
+
+        service_dir = os.path.join(self._systemd_path, '%s.d' % service)
+        if not os.path.isdir(service_dir):
+            os.mkdir(service_dir)
+
+        mixin_path = os.path.join(service_dir, '%s.conf' % label)
+        with open(mixin_path, 'w') as mixin_out:
+            mixin_out.write(mixin)

--- a/src/spacel/agent/mixin/cloudwatch_logs.py
+++ b/src/spacel/agent/mixin/cloudwatch_logs.py
@@ -1,0 +1,30 @@
+import logging
+
+from spacel.agent.mixin.base import BaseMixinWriter
+
+logger = logging.getLogger('spacel')
+
+
+class SetupCloudWatchLogs(BaseMixinWriter):
+    def __init__(self, systemd, meta):
+        super(SetupCloudWatchLogs, self).__init__(systemd)
+        self._meta = meta
+
+    def logs(self, manifest):
+        self._docker_logs(manifest)
+        # TODO: self._journald_logs ?
+
+    def _docker_logs(self, manifest):
+        docker_logging = manifest.logging.get('docker', {})
+        log_group = docker_logging.get('group')
+        if not log_group:
+            logger.debug('Docker logging not configured.')
+            return
+
+        self._write_mixin('docker.service', '10-logs', {
+            'DOCKER_OPTS': ('--log-driver awslogs' +
+                            ' --log-opt awslogs-region=%s' % self._meta.region +
+                            ' --log-opt awslogs-group=%s' % log_group)
+        })
+
+        self._systemd.restart('docker.service')

--- a/src/spacel/agent/mixin/cloudwatch_logs.py
+++ b/src/spacel/agent/mixin/cloudwatch_logs.py
@@ -11,10 +11,6 @@ class SetupCloudWatchLogs(BaseMixinWriter):
         self._meta = meta
 
     def logs(self, manifest):
-        self._docker_logs(manifest)
-        # TODO: self._journald_logs ?
-
-    def _docker_logs(self, manifest):
         docker_logging = manifest.logging.get('docker', {})
         log_group = docker_logging.get('group')
         if not log_group:
@@ -27,4 +23,5 @@ class SetupCloudWatchLogs(BaseMixinWriter):
                             ' --log-opt awslogs-group=%s' % log_group)
         })
 
+        logger.debug('Restarting docker.service with CW:L log driver.')
         self._systemd.restart('docker.service')

--- a/src/spacel/agent/mixin/cloudwatch_stats.py
+++ b/src/spacel/agent/mixin/cloudwatch_stats.py
@@ -1,0 +1,27 @@
+import logging
+
+from spacel.agent.mixin.base import BaseMixinWriter
+
+logger = logging.getLogger('spacel')
+CW_STATS_SERVICE = 'cloudwatch-stats.service'
+
+
+class SetupCloudWatchStats(BaseMixinWriter):
+    def __init__(self, systemd, instance_tags):
+        super(SetupCloudWatchStats, self).__init__(systemd)
+        self._instance_tags = instance_tags
+
+    def stats(self, manifest):
+        if not manifest.stats:
+            logger.debug('CloudWatch stats not enabled.')
+            return
+
+        tags = self._instance_tags.get()
+        asg = tags.get('aws:autoscaling:groupName')
+        # TODO: what about spotfleets?
+        if asg:
+            self._write_mixin(CW_STATS_SERVICE, '10-asg', {
+                'ASG_PARAMS': '--auto-scaling --auto-scaling-group=%s' % asg
+            })
+
+        self._systemd.start(CW_STATS_SERVICE)

--- a/src/spacel/agent/systemd.py
+++ b/src/spacel/agent/systemd.py
@@ -67,7 +67,8 @@ class SystemdUnits(object):
             if waiting_units:
                 if (time.time() - wait_start) > max_wait:
                     logger.error('Units failed to start after %ss: %s',
-                                 max_wait, ', '.join(sorted(waiting_units.keys())))
+                                 max_wait,
+                                 ', '.join(sorted(waiting_units.keys())))
                     return False
                 else:
                     time.sleep(poll_interval)
@@ -128,3 +129,11 @@ class SystemdUnits(object):
             if ext == '.timer':
                 timers.add(name)
         return timers
+
+    def start(self, unit_name):
+        self._manager.reload()
+        self._manager.start_unit(unit_name, 'replace')
+
+    def restart(self, unit_name):
+        self._manager.reload()
+        self._manager.restart_unit(unit_name, 'replace')

--- a/src/spacel/aws/__init__.py
+++ b/src/spacel/aws/__init__.py
@@ -4,4 +4,4 @@ from .eip import ElasticIpBinder
 from .elb import ElbHealthCheck
 from .kms import KmsCrypto
 from .meta import AwsMeta
-from .tag import TagWriter
+from .tag import InstanceTags

--- a/src/spacel/aws/eip.py
+++ b/src/spacel/aws/eip.py
@@ -139,22 +139,6 @@ class ElasticIpBinder(object):
         for older_lc in lc_by_age[:index_of_own]:
             for potential_victim in instance_lcs[older_lc]:
                 if potential_victim != own_id:
+                    logger.debug('Stealing EIP from %s, old LC.',
+                                 potential_victim)
                     return potential_victim
-
-        logger.debug('Stealing EIP from %s, old LC.', victim_instance)
-
-        # TODO:
-
-
-if __name__ == '__main__':
-    from spacel.aws import ClientCache
-
-    c = ClientCache('us-east-1')
-    eip = ElasticIpBinder(c)
-
-    eips = {
-        'eipalloc-03e78865': 'i-037f8a6bcf9ddd868',
-        'eipalloc-9794fbf1': 'i-0242ddb261efd1a43'
-    }
-    v = eip._victim('i-090cb55627eeb1052', eips)
-    print(v)

--- a/src/spacel/aws/tag.py
+++ b/src/spacel/aws/tag.py
@@ -3,10 +3,19 @@ import logging
 logger = logging.getLogger('spacel')
 
 
-class TagWriter(object):
+class InstanceTags(object):
     def __init__(self, clients, meta):
         self._ec2 = clients.ec2()
-        self._instance_id = meta.instance_id
+        self._instance_ids = [meta.instance_id]
+
+    def get(self):
+        instances = self._ec2.describe_instances(InstanceIds=self._instance_ids)
+        for reservation in instances.get('Reservations', ()):
+            for instance in reservation.get('Instances', ()):
+                if instance['InstanceId'] == self._instance_ids[0]:
+                    tags = instance.get('Tags', ())
+                    return {tag['Key']: tag['Value'] for tag in tags}
+        return {}
 
     def update(self, manifest):
         tags = manifest.tags
@@ -14,9 +23,6 @@ class TagWriter(object):
             logger.debug('Tags not set.')
             return
 
-        my_tags = [{'Key': k, 'Value': v} for k, v in tags.items() if k and v]
-
-        if my_tags:
-            self._ec2.create_tags(
-                Resources=[self._instance_id],
-                Tags=my_tags)
+        tags = [{'Key': k, 'Value': v} for k, v in tags.items() if k and v]
+        if tags:
+            self._ec2.create_tags(Resources=self._instance_ids, Tags=tags)

--- a/src/spacel/cli/services.py
+++ b/src/spacel/cli/services.py
@@ -7,7 +7,7 @@ import click
 from spacel.agent import (ApplicationEnvironment, FileWriter, SystemdUnits,
                           InstanceManager)
 from spacel.aws import (AwsMeta, ClientCache, CloudFormationSignaller,
-                        ElbHealthCheck, ElasticIpBinder, KmsCrypto, TagWriter)
+                        ElbHealthCheck, ElasticIpBinder, KmsCrypto, InstanceTags)
 from spacel.log import setup_logging, setup_watchtower
 from spacel.model import AgentManifest
 from spacel.volumes import VolumeBinder
@@ -69,7 +69,7 @@ def process_manifest(clients, meta, systemd, manifest):
     eip = ElasticIpBinder(clients, meta)
     ebs = VolumeBinder(clients, meta)
     elb = ElbHealthCheck(clients, meta)
-    tag = TagWriter(clients, meta)
+    tag = InstanceTags(clients, meta)
 
     # Act on manifest:
     tag.update(manifest)

--- a/src/spacel/cli/services.py
+++ b/src/spacel/cli/services.py
@@ -6,8 +6,10 @@ import click
 
 from spacel.agent import (ApplicationEnvironment, FileWriter, SystemdUnits,
                           InstanceManager)
+from spacel.agent.mixin import SetupCloudWatchLogs, SetupCloudWatchStats
 from spacel.aws import (AwsMeta, ClientCache, CloudFormationSignaller,
-                        ElbHealthCheck, ElasticIpBinder, KmsCrypto, InstanceTags)
+                        ElbHealthCheck, ElasticIpBinder, KmsCrypto,
+                        InstanceTags)
 from spacel.log import setup_logging, setup_watchtower
 from spacel.model import AgentManifest
 from spacel.volumes import VolumeBinder
@@ -71,6 +73,9 @@ def process_manifest(clients, meta, systemd, manifest):
     elb = ElbHealthCheck(clients, meta)
     tag = InstanceTags(clients, meta)
 
+    cw_logs = SetupCloudWatchLogs(systemd, meta)
+    cw_stats = SetupCloudWatchStats(systemd, tag)
+
     # Act on manifest:
     tag.update(manifest)
     for volume in manifest.volumes.values():
@@ -78,6 +83,9 @@ def process_manifest(clients, meta, systemd, manifest):
         # TODO: fail if attaching any volume fails.
     if not eip.assign_from(manifest):
         return False
+
+    cw_logs.logs(manifest)
+    cw_stats.stats(manifest)
 
     file_writer.write_files(manifest)
     if not systemd.start_units(manifest):

--- a/src/spacel/model/manifest.py
+++ b/src/spacel/model/manifest.py
@@ -1,4 +1,5 @@
 import logging
+
 from spacel.model.volume import SpaceVolume
 
 logger = logging.getLogger('spacel')
@@ -21,6 +22,7 @@ class AgentManifest(object):
         self.caches = params.get('caches', {})
         self.logging = params.get('logging', {})
         self.databases = params.get('databases', {})
+        self.stats = params.get('stats', False)
 
     @property
     def all_files(self):

--- a/src/test/agent/mixin/test_base.py
+++ b/src/test/agent/mixin/test_base.py
@@ -1,0 +1,25 @@
+import shutil
+import tempfile
+import unittest
+
+from spacel.agent.mixin.base import BaseMixinWriter
+
+
+class TestBaseMixinWriter(unittest.TestCase):
+    def setUp(self):
+        self.systemd = tempfile.mkdtemp()
+        self.mixin_writer = BaseMixinWriter(None, systemd_path=self.systemd)
+
+    def tearDown(self):
+        shutil.rmtree(self.systemd)
+
+    def test_write_mixin(self):
+        self.mixin_writer._write_mixin(
+            'test.service', '10-test', {
+                'FOO': 'bar'
+            })
+
+        with open(self.systemd + '/test.service.d/10-test.conf') as mixin_in:
+            mixin = [l.strip() for l in mixin_in.readlines()]
+        self.assertEquals('[Service]', mixin[0])
+        self.assertIn('Environment=', mixin[1])

--- a/src/test/agent/mixin/test_cloudwatch_logs.py
+++ b/src/test/agent/mixin/test_cloudwatch_logs.py
@@ -1,0 +1,44 @@
+import unittest
+
+from mock import MagicMock
+
+from spacel.agent.mixin.cloudwatch_logs import SetupCloudWatchLogs
+
+ASG_NAME = 'test-asg'
+
+
+class TestSetupCloudWatchLogs(unittest.TestCase):
+    def setUp(self):
+        self.systemd = MagicMock()
+        self.instance_tags = MagicMock()
+        self.instance_tags.get.return_value = {
+            'aws:autoscaling:groupName': ASG_NAME
+        }
+        self.meta = MagicMock()
+        self.meta.region = 'us-east-1'
+        self.logs = SetupCloudWatchLogs(self.systemd, self.meta)
+        self.logs._write_mixin = MagicMock()
+        self.manifest = MagicMock()
+
+    def test_logs_noop(self):
+        self.manifest.logging = {}
+
+        self.logs.logs(self.manifest)
+
+        self.logs._write_mixin.assert_not_called()
+        self.systemd.restart.assert_not_called()
+
+    def test_logs(self):
+        self.manifest.logging = {
+            'docker': {'group': 'test-group'}
+        }
+
+        self.logs.logs(self.manifest)
+
+        self.logs._write_mixin.assert_called_once_with(
+            'docker.service', '10-logs', {
+                'DOCKER_OPTS': '--log-driver awslogs'
+                               ' --log-opt awslogs-region=us-east-1'
+                               ' --log-opt awslogs-group=test-group'
+            })
+        self.systemd.restart.assert_called_once_with('docker.service')

--- a/src/test/agent/mixin/test_cloudwatch_stats.py
+++ b/src/test/agent/mixin/test_cloudwatch_stats.py
@@ -1,0 +1,39 @@
+import unittest
+
+from mock import MagicMock
+
+from spacel.agent.mixin.cloudwatch_stats import (SetupCloudWatchStats,
+                                                 CW_STATS_SERVICE)
+
+ASG_NAME = 'test-asg'
+
+
+class TestSetupCloudWatchStats(unittest.TestCase):
+    def setUp(self):
+        self.systemd = MagicMock()
+        self.instance_tags = MagicMock()
+        self.instance_tags.get.return_value = {
+            'aws:autoscaling:groupName': ASG_NAME
+        }
+        self.stats = SetupCloudWatchStats(self.systemd, self.instance_tags)
+        self.stats._write_mixin = MagicMock()
+        self.manifest = MagicMock()
+
+    def test_stats_disabled(self):
+        self.manifest.stats = False
+
+        self.stats.stats(self.manifest)
+
+        self.stats._write_mixin.assert_not_called()
+        self.systemd.start.assert_not_called()
+
+    def test_stats_cloudwatch(self):
+        self.manifest.stats = True
+
+        self.stats.stats(self.manifest)
+
+        self.stats._write_mixin.assert_called_once_with(
+            CW_STATS_SERVICE, '10-asg', {
+                'ASG_PARAMS': '--auto-scaling --auto-scaling-group=test-asg'
+            })
+        self.systemd.start.assert_called_with(CW_STATS_SERVICE)

--- a/src/test/agent/test_systemd.py
+++ b/src/test/agent/test_systemd.py
@@ -132,3 +132,16 @@ class TestSystemdUnits(unittest.TestCase):
         self.systemd.log_units(self.manifest)
 
         self.assertEquals(3, mock_subprocess.check_output.call_count)
+
+    def test_start(self):
+        self.systemd.start('test.service')
+        self.manager.reload.assert_called_once_with()
+        self.manager.start_unit.assert_called_once_with('test.service',
+                                                        'replace')
+
+    def test_restart(self):
+        self.systemd.restart('test.service')
+
+        self.manager.reload.assert_called_once_with()
+        self.manager.restart_unit.assert_called_once_with('test.service',
+                                                           'replace')

--- a/src/test/aws/test_tag.py
+++ b/src/test/aws/test_tag.py
@@ -1,28 +1,47 @@
-from spacel.aws.tag import TagWriter
+from spacel.aws.tag import InstanceTags
 from test.aws import MockedClientTest, INSTANCE_ID
 
 TAG_KEY = 'key'
 TAG_VALUE = 'value'
 
+TAGS_EC2 = [{'Key': TAG_KEY, 'Value': TAG_VALUE}]
+TAGS_PYTHON = {TAG_KEY: TAG_VALUE}
 
-class TestTagWriter(MockedClientTest):
+
+class TestInstanceTags(MockedClientTest):
     def setUp(self):
-        super(TestTagWriter, self).setUp()
-        self.tag_writer = TagWriter(self.clients, self.meta)
+        super(TestInstanceTags, self).setUp()
+        self.instance_tags = InstanceTags(self.clients, self.meta)
+        self.manifest.tags = TAGS_PYTHON
 
-        self.manifest.tags = {TAG_KEY: TAG_VALUE}
+    def test_get(self):
+        self.ec2.describe_instances.return_value = {
+            'Reservations': [{
+                'Instances': [{
+                    'InstanceId': INSTANCE_ID,
+                    'Tags': TAGS_EC2
+                }]
+            }]
+        }
+
+        tags = self.instance_tags.get()
+        self.assertEquals(TAGS_PYTHON, tags)
+
+    def test_get_missing(self):
+        tags = self.instance_tags.get()
+        self.assertEquals({}, tags)
 
     def test_update(self):
-        self.tag_writer.update(self.manifest)
+        self.instance_tags.update(self.manifest)
 
         self.ec2.create_tags.assert_called_once_with(
             Resources=[INSTANCE_ID],
-            Tags=[{'Key': TAG_KEY, 'Value': TAG_VALUE}]
+            Tags=TAGS_EC2
         )
 
     def test_update_empty(self):
         self.manifest.tags = ()
 
-        self.tag_writer.update(self.manifest)
+        self.instance_tags.update(self.manifest)
 
         self.ec2.create_tags.assert_not_called()


### PR DESCRIPTION
Functional tested on a spacel AMI via docker build: dat agility.
This is ready for functional testing as an AMI.

Docker logs bits tested via hack (just re-using `DeployLogGroup`); will pick up the spacel-provision support.